### PR TITLE
controller: controller_execute: delete client output and chomp output from publish hook before sending to subscribe hooks

### DIFF
--- a/node/lib/openshift-origin-node/model/v2_cart_model.rb
+++ b/node/lib/openshift-origin-node/model/v2_cart_model.rb
@@ -720,8 +720,13 @@ module OpenShift
             name = "OPENSHIFT_#{name}"
           end
 
-          File.open(PathUtils.join(path, name), 'w', 0666) do |f|
-            f.write(v)
+          pathname = PathUtils.join(path, name)
+          begin
+            File.open(pathname, 'w', 0666) do |f|
+              f.write(v)
+            end
+          rescue Exception => e
+            logger.warn "Got #{e.class} exception writing #{pathname}: #{e.message}"
           end
         end
       end
@@ -1222,6 +1227,8 @@ module OpenShift
         pairs = args[3].values[0].split("\n")
 
         pairs.each do |pair|
+          next if not pair.include? '='
+
           k, v    = pair.strip.split("=")
           envs[k] = v
         end


### PR DESCRIPTION
#### controller: `execute_connections`: delete and chomp client output

Filter client output out from the publish hooks output and chomp it before providing it as input to the subscribe hooks.

This commit fixes bug 1261540.
#### controller: `execute_connections`: reformat and comment

Reformat `execute_connections` to return right away if the application is not scalable rather than wrapping the entire function in an `if` block.

Reformat the block that calls the publish hooks to go to the next hook right away if the current hook did not run successfully rather than wrapping the entire block in an `if` block.

Add some comments.
#### Log errors and skip bad lines when writing environment variables

`write_environment_variables`: Rescue and log exceptions raised when writing out the file.

`set_connection_hook_env_vars`: Skip malformed lines that do not include the '=' key-value separator.
